### PR TITLE
fix: When downloading the database, the permissions were not available.

### DIFF
--- a/docker-compose/postgresql/postgres.Dockerfile
+++ b/docker-compose/postgresql/postgres.Dockerfile
@@ -1,5 +1,12 @@
 FROM postgres:13
 
+ENV HOME_PATH_ON_CONTAINERS=/home/adempiere
+ENV POSTGRES_DB_BACKUP_PATH_ON_CONTAINER=${HOME_PATH_ON_CONTAINERS}/postgres_backups
+
+
+RUN mkdir -p $POSTGRES_DB_BACKUP_PATH_ON_CONTAINER && \
+	chown -R postgres:postgres $POSTGRES_DB_BACKUP_PATH_ON_CONTAINER
+
 
 # Command "wget" will be used for downloading the standard Adempiere Database in
 # initdb.sh, instead of downloading it manually and copying it into the container.
@@ -12,8 +19,8 @@ RUN echo 'Update APT package handling utility' && \
 	echo 'wget installed'
 
 
-COPY --chown=1 initdb.sh /docker-entrypoint-initdb.d
-COPY --chown=1 after_run/*.sql /tmp/after_run/
 
+COPY --chown=postgres:postgres initdb.sh /docker-entrypoint-initdb.d/
+COPY --chown=postgres:postgres after_run/*.sql /tmp/after_run/
 
 RUN chmod +x /docker-entrypoint-initdb.d/initdb.sh


### PR DESCRIPTION
When disable backup volume https://github.com/adempiere/adempiere-ui-gateway/blob/main/docker-compose/docker-compose-standard.yml#L25 download backup.

Error
```log
adempiere-ui-gateway.postgresql        | server started
adempiere-ui-gateway.postgresql        | 
adempiere-ui-gateway.postgresql        | /usr/local/bin/docker-entrypoint.sh: running /docker-entrypoint-initdb.d/initdb.sh
adempiere-ui-gateway.postgresql        | Starting DB initialization.
adempiere-ui-gateway.postgresql        | Check if user 'adempiere' exists.
adempiere-ui-gateway.postgresql        | The role 'adempiere' does not exist -->> it will be created and restored
adempiere-ui-gateway.postgresql        | ALTER ROLE
adempiere-ui-gateway.postgresql        | Check if database 'adempiere' exists.
adempiere-ui-gateway.postgresql        | The database 'adempiere' does not exist -->> it will be created and restored
adempiere-ui-gateway.postgresql        | Restore of database 'adempiere' starting...
adempiere-ui-gateway.postgresql        | Check if a seed restore file exists (/home/adempiere/postgres_backups/seed.backup)
adempiere-ui-gateway.postgresql        | File /home/adempiere/postgres_backups/seed.backup does not exist -->> Proceed to restore DB using ADempiere's seed.
adempiere-ui-gateway.postgresql        | I am the user:  postgres
adempiere-ui-gateway.postgresql        | /docker-entrypoint-initdb.d/initdb.sh: line 36: cd: /home/adempiere/postgres_backups: No such file or directory
adempiere-ui-gateway.postgresql        | I am on directory:  /
adempiere-ui-gateway.postgresql        | Downloading ADempiere artifact from Github... It may take some time
adempiere-ui-gateway.postgresql        | --2025-04-13 21:44:14--  https://github.com/adempiere/adempiere/releases/download/3.9.4/adempiere_ui_postgresql_seed.tar.gz
adempiere-ui-gateway.postgresql        | Resolving github.com (github.com)... 140.82.112.4
adempiere-ui-gateway.postgresql        | Connecting to github.com (github.com)|140.82.112.4|:443... connected.
adempiere-ui-gateway.postgresql        | HTTP request sent, awaiting response... 302 Found
adempiere-ui-gateway.postgresql        | Location: https://objects.githubusercontent.com/github-production-release-asset-2e65be/28942332/c6b10703-f594-4348-bdc5-584de4a28eb9?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=releaseassetproduction%2F20250414%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250414T014415Z&X-Amz-Expires=300&X-Amz-Signature=964acf63c770ddd94404ed49c242ea89e7f66422d601e34bee181203e35d2bf2&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dadempiere_ui_postgresql_seed.tar.gz&response-content-type=application%2Foctet-stream [following]
adempiere-ui-gateway.postgresql        | --2025-04-13 21:44:15--  https://objects.githubusercontent.com/github-production-release-asset-2e65be/28942332/c6b10703-f594-4348-bdc5-584de4a28eb9?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=releaseassetproduction%2F20250414%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250414T014415Z&X-Amz-Expires=300&X-Amz-Signature=964acf63c770ddd94404ed49c242ea89e7f66422d601e34bee181203e35d2bf2&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dadempiere_ui_postgresql_seed.tar.gz&response-content-type=application%2Foctet-stream
adempiere-ui-gateway.postgresql        | Resolving objects.githubusercontent.com (objects.githubusercontent.com)... 185.199.110.133, 185.199.108.133, 185.199.109.133, ...
adempiere-ui-gateway.postgresql        | Connecting to objects.githubusercontent.com (objects.githubusercontent.com)|185.199.110.133|:443... connected.
adempiere-ui-gateway.postgresql        | HTTP request sent, awaiting response... 200 OK
adempiere-ui-gateway.postgresql        | Length: 57596025 (55M) [application/octet-stream]
adempiere-ui-gateway.postgresql        | adempiere_ui_postgresql_seed.tar.gz: Permission denied
adempiere-ui-gateway.postgresql        | 
adempiere-ui-gateway.postgresql        | Cannot write to ‘adempiere_ui_postgresql_seed.tar.gz’ (Permission denied).
adempiere-ui-gateway.postgresql        | Result from ls -la:  total 76 drwxr-xr-x 1 root root 4096 Apr 13 21:44 . drwxr-xr-x 1 root root 4096 Apr 13 21:44 .. lrwxrwxrwx 1 root root 7 Apr 6 20:00 bin -> usr/bin drwxr-xr-x 2 root root 4096 Mar 7 13:30 boot drwxr-xr-x 5 root root 340 Apr 13 21:44 dev drwxr-xr-x 1 root root 4096 Apr 12 20:02 docker-entrypoint-initdb.d -rwxr-xr-x 1 root root 0 Apr 13 21:44 .dockerenv drwxr-xr-x 1 root root 4096 Apr 13 21:44 etc drwxr-xr-x 2 root root 4096 Mar 7 13:30 home lrwxrwxrwx 1 root root 7 Apr 6 20:00 lib -> usr/lib lrwxrwxrwx 1 root root 9 Apr 6 20:00 lib64 -> usr/lib64 drwxr-xr-x 2 root root 4096 Apr 6 20:00 media drwxr-xr-x 2 root root 4096 Apr 6 20:00 mnt drwxr-xr-x 2 root root 4096 Apr 6 20:00 opt dr-xr-xr-x 486 root root 0 Apr 13 21:44 proc drwx------ 1 root root 4096 Apr 7 21:22 root drwxr-xr-x 1 root root 4096 Apr 7 21:22 run lrwxrwxrwx 1 root root 8 Apr 6 20:00 sbin -> usr/sbin drwxr-xr-x 2 root root 4096 Apr 6 20:00 srv dr-xr-xr-x 13 root root 0 Apr 13 21:44 sys drwxrwxrwt 1 root root 4096 Apr 12 20:02 tmp drwxr-xr-x 1 root root 4096 Apr 6 20:00 usr drwxr-xr-x 1 root root 4096 Apr 6 20:00 var
adempiere-ui-gateway.postgresql        | Check file adempiere_ui_postgresql_seed.tar.gz was downloaded
adempiere-ui-gateway.postgresql        | ERROR: File adempiere_ui_postgresql_seed.tar.gz could not be downloaded.
adempiere-ui-gateway.postgresql        | Process will be stopped.
adempiere-ui-gateway.postgresql exited with code 0
```



Corrected
```
adempiere-ui-gateway.postgresql        |  55950K .......... .......... .......... .......... .......... 99% 4.09M 0s
adempiere-ui-gateway.postgresql        |  56000K .......... .......... .......... .......... .......... 99% 5.49M 0s
adempiere-ui-gateway.postgresql        |  56050K .......... .......... .......... .......... .......... 99% 4.00M 0s
adempiere-ui-gateway.postgresql        |  56100K .......... .......... .......... .......... .......... 99% 3.96M 0s
adempiere-ui-gateway.postgresql        |  56150K .......... .......... .......... .......... .......... 99% 4.27M 0s
adempiere-ui-gateway.postgresql        |  56200K .......... .......... .......... .......... ......    100% 7.32M=7.3s
adempiere-ui-gateway.postgresql        | 
adempiere-ui-gateway.postgresql        | 2025-04-13 21:59:52 (7.53 MB/s) - ‘/tmp/tmp.Rc4xyqBjy3/adempiere_ui_postgresql_seed.tar.gz’ saved [57596025/57596025]
adempiere-ui-gateway.postgresql        | 
adempiere-ui-gateway.postgresql        | Result from ls -la:  total 8 drwxr-xr-x 2 postgres postgres 4096 Apr 13 21:30 . drwxr-xr-x 3 root root 4096 Apr 13 21:30 ..
adempiere-ui-gateway.postgresql        | Check file /tmp/tmp.Rc4xyqBjy3/adempiere_ui_postgresql_seed.tar.gz was downloaded
adempiere-ui-gateway.postgresql        | File /tmp/tmp.Rc4xyqBjy3/adempiere_ui_postgresql_seed.tar.gz was downloaded
adempiere-ui-gateway.postgresql        | Unpack /tmp/tmp.Rc4xyqBjy3/adempiere_ui_postgresql_seed.tar.gz here... It may take some time
adempiere-ui-gateway.postgresql        | adempiere_ui_postgresql_seed.backup
adempiere-ui-gateway.postgresql        | Result from ls -la:  total 8 drwxr-xr-x 2 postgres postgres 4096 Apr 13 21:30 . drwxr-xr-x 3 root root 4096 Apr 13 21:30 ..
adempiere-ui-gateway.postgresql        | total 118720
adempiere-ui-gateway.postgresql        | drwx------ 2 postgres postgres     4096 Apr 13 21:59 .
adempiere-ui-gateway.postgresql        | drwxrwxrwt 1 root     root         4096 Apr 13 21:59 ..
adempiere-ui-gateway.postgresql        | -rw-r--r-- 1 postgres postgres 63963136 May 29  2024 adempiere_ui_postgresql_seed.backup
adempiere-ui-gateway.postgresql        | -rw-r--r-- 1 postgres postgres 57596025 May 29  2024 adempiere_ui_postgresql_seed.tar.gz
adempiere-ui-gateway.postgresql        | Rename adempiere_ui_postgresql_seed.backup to seed.backup. Any existing file with same name will disappear!
adempiere-ui-gateway.postgresql        | Result from ls -la:  total 56256 drwx------ 2 postgres postgres 4096 Apr 13 21:59 . drwxrwxrwt 1 root root 4096 Apr 13 21:59 .. -rw-r--r-- 1 postgres postgres 57596025 May 29 2024 adempiere_ui_postgresql_seed.tar.gz
adempiere-ui-gateway.postgresql        | Delete /tmp/tmp.Rc4xyqBjy3/adempiere_ui_postgresql_seed.tar.gz
adempiere-ui-gateway.postgresql        | Result from ls -la:  total 62476 drwxr-xr-x 1 postgres postgres 4096 Apr 13 21:59 . drwxr-xr-x 1 root root 4096 Apr 13 21:30 .. -rw-r--r-- 1 postgres postgres 63963136 May 29 2024 seed.backup
adempiere-ui-gateway.postgresql        | Ready to start DB restore
adempiere-ui-gateway.postgresql        | Restoring ADempiere artifact from Github... It may take some time
adempiere-ui-gateway.postgresql        | Restore with 'pg_restore'
adempiere-ui-gateway.postgresql        | pg_restore: connecting to database for restore
adempiere-ui-gateway.postgresql        | pg_restore: creating SCHEMA "adempiere"
adempiere-ui-gateway.postgresql        | pg_restore: creating EXTENSION "pgcrypto"
adempiere-ui-gateway.postgresql        | pg_restore: creating COMMENT "EXTENSION pgcrypto"
```


resolve https://github.com/adempiere/adempiere-ui-gateway/issues/133