### PR TITLE
fix: Change sh scripts with docker compose file name.

### DIFF
--- a/docker-compose/start-all.sh
+++ b/docker-compose/start-all.sh
@@ -64,9 +64,9 @@ export $PROFILES
 
 
 # 3.- Execute docker compose
-DOCKER_COMPOSE_FILE=docker-compose-profile.yml
+DOCKER_COMPOSE_FILE=docker-compose.yml
 echo "Docker Compose will be executed with file: \"$DOCKER_COMPOSE_FILE\""
 #docker compose -f $DOCKER_COMPOSE_FILE --dry-run up -d
-COMPOSE_PROFILES=$PROFILES docker compose -f docker-compose-profile.yml up
+COMPOSE_PROFILES=$PROFILES docker compose -f $DOCKER_COMPOSE_FILE up
 
 echo "Docker Compose started"

--- a/docker-compose/stop-and-delete-all.sh
+++ b/docker-compose/stop-and-delete-all.sh
@@ -8,7 +8,7 @@ while true; do
                 DOCKER_COMPOSE_FILE=docker-compose.yml
                 echo "All services started with the Docker Compose file \"$DOCKER_COMPOSE_FILE\" will be stopped!"
                 # -v --> include named volumes declared in the "volumes" section of the Compose file and anonymous volumes attached to containers.
-                docker compose -f $docker_compose_file down -v
+                docker compose -f $DOCKER_COMPOSE_FILE down -v
 
 
                 docker rmi -f $(docker compose images -q)
@@ -21,5 +21,3 @@ while true; do
         * ) echo "Please answer yes or no.";;
     esac
 done
-
-


### PR DESCRIPTION
```shell
cd docker-compose
./start-all.sh all
```

Generates error.
```log
Docker Compose will be executed with file: "docker-compose-profile.yml"
open /home/edwin/workspace/sw/adempiere-ui-gateway/docker-compose/docker-compose-profile.yml: no such file or directory
```

resolves https://github.com/Systemhaus-Westfalia/adempiere-ui-gateway/issues/10